### PR TITLE
Replace member names containing . with _

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,9 @@ Generates strongly-typed resource classes for looking up localized strings.
 
 ## Usage
 
-Install the [`Localizati18n.ResourceGenerator`](https://www.nuget.org/packages/Localizati18n.ResourceGenerator/) package in your resource project:
+Install the [`Localizati18n.ResourceGenerator`](https://www.nuget.org/packages/Localizati18n.ResourceGenerator/) and [`Localizati18n.ResourceManager`](https://www.nuget.org/packages/Localizati18n.ResourceManager/) packages in your resource project:
 
-```psl
-dotnet add package Localizati18n.ResourceGenerator
-```
-
-Additionally you also want to install the corresponding [`ResourceManager`](https://www.nuget.org/packages/Localizati18n.ResourceManager/)
-
-Make sure to copy your JSON resource files to your output directory
+Make sure to copy your JSON resource files to your output directory and mark them as EmbeddedResource
 
 If you want to use a custom namespace for your resources, add a `CustomToolNamespace` tag to your embedded resource
 i.e.
@@ -25,7 +19,21 @@ i.e.
 ```
 
 By default, source generators will not persist the generated files to disk. In many cases, it's desirable to have the generated source in version control though.
+I also found that Intellisense doesn't work without it, so please do copy those files if you encounter any issues
 
 Luckily, there's another tag you can use. Simply add `<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>` to your `PropertyGroup`
 
-I haven't found a way to copy those to your project folder yet. If you know how, feel free to contribute.
+You can then add a `<CompilerGeneratedFilesOutputPath></CompilerGeneratedFilesOutputPath>` if desired and copy the resource file after build.
+```xml
+<!--    This is important because the compiler would complain about the duplicate file otherwise -->
+<Target Name="RemovePreviouslyGeneratedFile" BeforeTargets="BeforeCompile">
+    <Delete Files="Localization.cs" ContinueOnError="true" />
+</Target>
+
+<Target Name="CopyGeneratedFile" AfterTargets="AfterBuild">
+    <Copy SourceFiles="Generated\Localizati18n.ResourceGenerator\Localizati18n.ResourceGenerator.SourceGenerator\Localization.cs" DestinationFolder="$(ProjectDir)" />
+    <RemoveDir Directories="Generated" />
+</Target>
+```
+
+Note that for some reason this does not work on rebuild. If you figure out why, please submit a PR to the example project

--- a/samples/Localizati18n.WebApp/Localizati18n.WebApp.csproj
+++ b/samples/Localizati18n.WebApp/Localizati18n.WebApp.csproj
@@ -27,6 +27,7 @@
       </PackageReference>
     </ItemGroup>
 
+<!--    This is important because the compiler would complain about the duplicate file otherwise -->
     <Target Name="RemovePreviouslyGeneratedFile" BeforeTargets="BeforeCompile">
         <Delete Files="Localization.cs" ContinueOnError="true" />
     </Target>

--- a/samples/Localizati18n.WebApp/Localizati18n.WebApp.csproj
+++ b/samples/Localizati18n.WebApp/Localizati18n.WebApp.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
 
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -19,20 +19,21 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Localizati18n.ResourceManager" Version="1.0.3" />
       <PackageReference Include="System.Globalization" Version="4.3.0" />
-      <PackageReference Include="Localizati18n.ResourceGenerator" Version="1.0.0">
+      <PackageReference Include="Localizati18n.ResourceGenerator" Version="1.0.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-        <MySourceFiles Include="\home\curtisy\Projects\dotNet\Localizati18n\Localizati18n.WebApp\obj\GeneratedFiles\Localizati18n.ResourceGenerator\Localizati18n.ResourceGenerator.SourceGenerator\*.cs" />
-    </ItemGroup>
-
-    <Target Name="AfterBuild">
-        <Copy SourceFiles="$(MySourceFiles)" DestinationFolder="$(ProjectDir)" />
+    <Target Name="RemovePreviouslyGeneratedFile" BeforeTargets="BeforeCompile">
+        <Delete Files="Localization.cs" ContinueOnError="true" />
     </Target>
 
+    <Target Name="CopyGeneratedFile" AfterTargets="AfterBuild">
+        <Copy SourceFiles="Generated\Localizati18n.ResourceGenerator\Localizati18n.ResourceGenerator.SourceGenerator\Localization.cs" DestinationFolder="$(ProjectDir)" />
+        <RemoveDir Directories="Generated" />
+    </Target>
 
 </Project>

--- a/samples/Localizati18n.WebApp/Localization.cs
+++ b/samples/Localizati18n.WebApp/Localization.cs
@@ -1,0 +1,18 @@
+﻿namespace Localization
+{
+    using System.Globalization;
+    using Localizati18n.ResourceManager;
+
+    public static class Localization
+    {
+        private static JsonResourceManager? s_ResourceManager;
+        public static JsonResourceManager ResourceManager => s_ResourceManager ??= new JsonResourceManager("Localization.Localization", typeof(Localization).Assembly, "Localization");
+        public static CultureInfo? ResourceCulture { get; set; }
+
+        public static string Greeting => ResourceManager.GetString(nameof(Greeting), ResourceCulture)!;
+        public static string Thanks => ResourceManager.GetString(nameof(Thanks), ResourceCulture)!;
+        public static string Farewell => ResourceManager.GetString(nameof(Farewell), ResourceCulture)!;
+        public static string SampleSentence => ResourceManager.GetString(nameof(SampleSentence), ResourceCulture)!;
+        public static string MultiLineSentence => ResourceManager.GetString(nameof(MultiLineSentence), ResourceCulture)!;
+    }
+}

--- a/src/Localizati18n.ResourceGenerator/Generator.cs
+++ b/src/Localizati18n.ResourceGenerator/Generator.cs
@@ -65,7 +65,7 @@
                       .AddAccessorListAccessors(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
                                                 AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(Token(SyntaxKind.SemicolonToken))));
 
-    private static MemberDeclarationSyntax CreateMember(string name, string value) =>
+    private static MemberDeclarationSyntax CreateMember(string name) =>
       PropertyDeclaration(IdentifierName("string"), name)
         .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
         .WithExpressionBody(ArrowExpressionClause(PostfixUnaryExpression(SyntaxKind.SuppressNullableWarningExpression,
@@ -81,9 +81,9 @@
                       .AddMembers(this.CreateClass()
                                     .AddMembers(members.ToArray())))
         .NormalizeWhitespace();
-
+    
     public CompilationUnitSyntax Generate() =>
       this.GetCompilationUnit(JsonSerializer.Deserialize<Dictionary<string, string>>(new StreamReader(this.resourceStream).ReadToEnd())
-                                .Select(kv => CreateMember(kv.Key, kv.Value)));
+                                .Select(kv => CreateMember(kv.Key.Replace('.', '_'))));
   }
 }

--- a/src/Localizati18n.ResourceGenerator/Localizati18n.ResourceGenerator.csproj
+++ b/src/Localizati18n.ResourceGenerator/Localizati18n.ResourceGenerator.csproj
@@ -12,8 +12,8 @@
         <IncludeSymbols>false</IncludeSymbols>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <DevelopmentDependency>true</DevelopmentDependency>
-        <Version>1.0.3</Version>
-        <PackageVersion>1.0.3</PackageVersion>
+        <Version>1.0.4</Version>
+        <PackageVersion>1.0.4</PackageVersion>
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
         <Copyright>2021 curtisy1</Copyright>
         <PackageProjectUrl>https://github.com/curtisy1/Localizati18n</PackageProjectUrl>

--- a/src/Localizati18n.ResourceManager/Localizati18n.ResourceManager.csproj
+++ b/src/Localizati18n.ResourceManager/Localizati18n.ResourceManager.csproj
@@ -7,8 +7,8 @@
         <Authors>curtisy1</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>Resource Designer Manager</Description>
-        <Version>1.0.3</Version>
-        <PackageVersion>1.0.3</PackageVersion>
+        <Version>1.0.4</Version>
+        <PackageVersion>1.0.4</PackageVersion>
         <Copyright>2021 curtisy1</Copyright>
         <PackageProjectUrl>https://github.com/curtisy1/Localizati18n</PackageProjectUrl>
         <RepositoryUrl>https://github.com/curtisy1/Localizati18n</RepositoryUrl>


### PR DESCRIPTION
Resources that have a key of A.B.C would get treated as Namespace.Class.Method otherwise